### PR TITLE
Make this work with Next.js 12.1.x

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -30,7 +30,11 @@ class DocumentWithApollo extends Document {
      * Render the page through Apollo's `getDataFromTree` so the cache is populated.
      * Unfortunately this renders the page twice per request... There may be a way around doing this, but I haven't quite ironed that out yet.
      */
-    await getDataFromTree(<ctx.AppTree {...ctx.appProps} />);
+    await getDataFromTree(
+      <ApolloProvider client={apolloClient}>
+        <ctx.AppTree {...ctx.appProps} />
+      </ApolloProvider>
+    );
 
     /**
      * Render the page as normal, but now that ApolloClient is initialized and the cache is full, each query will actually work.


### PR DESCRIPTION
With 12.1.x you receive a following error otherwise:

```
Invariant Violation: Could not find "client" in the context or passed in as an option. Wrap the root component in an <ApolloProvider>, or pass an ApolloClient instance in via options.
```

Seems like _app is NOT processed during the server render for some reason when _document is present.